### PR TITLE
Zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -24,8 +24,11 @@ source $ZSH/oh-my-zsh.sh
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
 
-autoload -U promptinit; promptinit
-prompt pure
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	# loading this causes problems in Linux, only load if on MacOS
+	autoload -U promptinit; promptinit
+	prompt pure
+fi
 
 # For a full list of active aliases, run `alias`.
 alias py="python3"

--- a/.zshrc
+++ b/.zshrc
@@ -3,7 +3,7 @@ C_INCLUDE_PATH=/usr/local/include
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH="/Users/taylorgamache/.oh-my-zsh"
+export ZSH="$HOME"/.oh-my-zsh
 
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="robbyrussell"


### PR DESCRIPTION
1. change the path to oh-my-zsh installation to start with $HOME to work on both MacOS and Linux
2. before loading pure prompt, make sure OS is MacOS. It causes issues with Linux.